### PR TITLE
unenrol instructors even if it is their last section

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -997,8 +997,7 @@ class enrol_ues_plugin extends enrol_plugin {
                 $settings        = cps_setting::get_to_name($setting_params);
                 $setting         = !empty($settings['creation_visible']) ? $settings['creation_visible'] : false;
 
-                //@todo1 Use the site default rather tham hard-coding '0'.
-                $course->visible = isset($setting->value) ? $setting->value : 0;
+                $course->visible = isset($setting->value) ? $setting->value : get_config('moodlecourse', 'visible');
 
                 $DB->update_record('course', $course);
 


### PR DESCRIPTION
Removes check for 'last section'. With this change, everyone, including the last remaining primary instructor, will be disenrolled at CPS unwant time.

Everyone is re-enrolled when unwant is un-checked, as usual.
